### PR TITLE
# EDIT - used RCC_QP for user attributes and certificates caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,3 +67,11 @@ target_link_libraries(run_test
     ${BOTAN_LIBS}
 )
 
+add_executable(rccqp_test test/rccqp_test.cpp ${SOURCE_FILES} ${HEADER_FILES})
+target_include_directories(rccqp_test PRIVATE include/ /usr/local/include)
+target_link_libraries(rccqp_test
+    PRIVATE
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+    ${Boost_LIBRARIES}
+    ${BOTAN_LIBS}
+)

--- a/include/rcc_qp.hpp
+++ b/include/rcc_qp.hpp
@@ -4,392 +4,320 @@
  * For commercial use, contact nyang@inha.ac.kr
  */
 
-#ifndef GRUUTSCE_RCC_QP_HPP
-#define GRUUTSCE_RCC_QP_HPP
+#ifndef TETHYS_SCE_RCC_QP_HPP
+#define TETHYS_SCE_RCC_QP_HPP
 
 #define USE_BOTAN_HASH 1
 
-#include <stdint.h>
-#include <stdlib.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <limits.h>
-#include <string.h>
-#include <time.h>
-#include <stdbool.h>
-#include <math.h>
 #include <memory>
-#include <vector>
-#include <algorithm>
 #include <random>
-#include <cstring>
+#include <string>
+#include <vector>
+#include <iostream>
+#include <queue>
+#include <list>
+#include <deque>
 
 #ifdef USE_BOTAN_HASH
 #include <botan-2/botan/hash.h>
+#include <cstring>
 #else
 #endif
 
 namespace tethys {
 
+using namespace std;
+
 constexpr int HASH_TABLE_SIZE = 1048576; // 0x100000;
 constexpr int CACHE_SIZE = 131072; // ‬(1 << 17);
 constexpr int JUMP_THRESHOLD = 100;	// hashtable jump JUMP_THRESHOLD
-constexpr int VIRTUAL_VECTOER_SIZE = 8;
+constexpr int VIRTUAL_VECTOR_SIZE = 8;
 constexpr int LC_COUNTER_SINGLEFR_IDXSIZE = 786432; // 3*1024*1024/4;			// single layer Flow Regulator를 사용할 때 변수
 constexpr int LC_COUNTER_DOUBLEFRE_IDXSIZE = 4718592; // 3*1024*1024/4*6;		// double layer Flow Regulator를 사용할 때 변수
 
-struct input_array_entry {
+
+struct Entry_t {
   uint64_t hv;
-  std::shared_ptr<input_array_entry> next;
-  input_array_entry() : hv(0) {}
-};
-
-struct lru_entry {
-  uint64_t hash_value;
-  std::shared_ptr<lru_entry> prev;
-  std::shared_ptr<lru_entry> next;
-  lru_entry() : hash_value(0){}
-};
-
-struct entry_t {
-  uint64_t hash_value;
   uint64_t timestamp;
   float total_counter;
   std::string data;
-  entry_t() : hash_value(0), timestamp(0), total_counter(0.0){}
+  Entry_t() : hv(0), timestamp(0), total_counter(0.0){}
 };
 
-struct hashtable_t {
+struct HashTable_t {
   uint32_t usage;
   uint32_t size;
   uint64_t insert;
   uint64_t total_jump;
   uint64_t eviction;
-  std::vector<entry_t> table;
-  hashtable_t() : usage(0), size(0), insert(0), total_jump(0), eviction(0){}
+  std::vector<Entry_t> table;
+  HashTable_t() : usage(0), size(0), insert(0), total_jump(0), eviction(0){}
 };
 
-struct rcc32_t {
+struct RCC32_t {
   uint32_t memory_fr_limit;
   std::vector<uint32_t> rcounter;
-  hashtable_t htable;
-  rcc32_t() : memory_fr_limit(0){}
+  HashTable_t htable;
+  RCC32_t() : memory_fr_limit(0){}
 };
 
-
-struct chain_entry {
+template<typename T>
+struct DataEntry {
   uint64_t hv;
-  std::shared_ptr<chain_entry> next;
-  chain_entry() : hv(0){}
+  std::vector<uint8_t> rhv;
+  T data;
 };
 
-struct chain_hash_table {
+template<typename T>
+struct ChainHashTable {
   uint64_t usage;
   uint64_t insert;
   uint64_t evict;
-  std::vector<std::shared_ptr<chain_entry>> htable;
-  chain_hash_table() : usage(0), insert(0), evict(0){}
+  std::vector<std::list<DataEntry<T>>> htable;
 };
 
+template<typename DATA_T>
 class RCCQP {
 private:
-  std::shared_ptr<chain_hash_table> hash_table;
-  std::shared_ptr<rcc32_t> rcc;
-  bool rcc_qp_flag;
-  std::shared_ptr<lru_entry> lru_head;
-  std::shared_ptr<lru_entry> lru_tail;
-  std::shared_ptr<input_array_entry> input_array_head;
-  std::shared_ptr<input_array_entry> input_array_tail;
+  ChainHashTable<DATA_T> m_ch_table;
+  RCC32_t m_rcc;
+  bool m_rcc_qp_flag;
+  std::list<uint64_t> m_lru_list;
   std::mt19937 prng;
 
 public:
-  RCCQP() : rcc_qp_flag(false){
+  RCCQP() : m_rcc_qp_flag(false){
     std::random_device rand_device;
     prng.seed(rand_device());
+    clear();
   }
 
   ~RCCQP(){
     chainClear();
   }
 
-  int test() {
-    uint64_t hv;
-
-    reset();
-
-    rcc_qp_flag = false;
+  void clear(){
+    chainInit();
+    m_rcc_qp_flag = false;
     lruInit();
     rccCreate(1);
-
-    scanf("%" PRIu64, &hv);
-    while (hv != 0) {
-      inputArrayInsert(hv);
-      hv = 0;
-      scanf("%" PRIu64, &hv);
-    }
-
-    hv = inputArrayDelete();
-    while (hv != 0)
-    {
-      if (chainSearch(hv)){
-        hv = inputArrayDelete();
-
-        if (rcc_qp_flag)
-          rcc_qp_flag = false;
-        continue;
-      }
-
-      if (rcc_qp_flag){
-        chainInsert(hv);
-        rcc_qp_flag = false;
-      }
-
-      hv = inputArrayDelete();
-    }
-
-    return 0;
   }
+
+  bool push(const std::string &key, const DATA_T& data) {
+    std::vector<uint8_t> rhv;
+    auto hv = hash(key,rhv);
+
+    if (chainSearch(hv,rhv)){
+      if (m_rcc_qp_flag)
+        m_rcc_qp_flag = false;
+
+      return chainUpdate(hv,rhv,data);
+    }
+
+    if (m_rcc_qp_flag){
+      chainInsert(hv, rhv, data);
+      m_rcc_qp_flag = false;
+      return true;
+    }
+
+    return false;
+  }
+
+  std::optional<DATA_T> get(const std::string &key){
+    std::vector<uint8_t> rhv;
+    auto hv = hash(key,rhv);
+
+    return chainGet(hv,rhv);
+  }
+
+  void erase(const std::string &key) {
+    std::vector<uint8_t> rhv;
+    auto hv = hash(key,rhv);
+    chainDelete(hv);
+  }
+
 
 private:
 
-  void reset(){
-    inputArrayInit();
-    chainInit();
-  }
-
-  void inputArrayInit(){
-    input_array_head = nullptr;
-    input_array_tail = nullptr;
-  }
-
   void chainClear(){
-    if(hash_table != nullptr) {
-      for(int i = 0; i < hash_table->htable.size(); ++i) {
-        hash_table->htable[i] = nullptr;
-      }
-    }
-  }
-
-  void inputArrayInsert(uint64_t hv){
-    std::shared_ptr<input_array_entry> new_entry(new input_array_entry);
-    new_entry->hv = hv;
-    new_entry->next = nullptr;
-
-    if (input_array_head == nullptr) {
-      input_array_head = new_entry;
-      input_array_tail = new_entry;
-    }
-    else {
-      input_array_tail->next = new_entry;
-      input_array_tail = new_entry;
-    }
-  }
-
-  uint64_t inputArrayDelete(){
-    if (input_array_head == nullptr)
-      return 0;
-
-    uint64_t ret_val = input_array_head->hv;
-
-    if (input_array_head->next == nullptr)
-      input_array_head = nullptr;
-    else
-      input_array_head = input_array_head->next;
-
-    return ret_val;
+    for(auto &each : m_ch_table.htable)
+      each.clear();
+    m_ch_table.htable.clear();
   }
 
   void chainInit() {
-
     chainClear();
-
-    hash_table.reset(new chain_hash_table);
-    hash_table->htable.resize(HASH_TABLE_SIZE);
-
-    for (uint32_t i = 0; i < HASH_TABLE_SIZE; ++i)
-      hash_table->htable[i] = nullptr;
-
-    hash_table->evict = 0;
-    hash_table->insert = 0;
-    hash_table->usage = 0;
+    m_ch_table.htable.resize(HASH_TABLE_SIZE);
+    m_ch_table.evict = 0;
+    m_ch_table.insert = 0;
+    m_ch_table.usage = 0;
   }
 
-  bool chainSearch(uint64_t hv){
+  bool chainSearch(uint64_t hv, std::vector<uint8_t> &rhv){
     lruUpdate(hv);
     singleFREncode(hv);
     uint32_t idx = hv % HASH_TABLE_SIZE;
 
-    std::shared_ptr<chain_entry> ptr = hash_table->htable[idx];
+    m_ch_table.htable[idx];
 
-    if (ptr == nullptr)
+    if (m_ch_table.htable[idx].empty())
       return false;
 
-    if (ptr->hv == hv)
-      return true;
-
-
-    while (ptr->next != nullptr){
-      ptr = ptr->next;
-
-      if (ptr->hv == hv)
+    for (auto itr = m_ch_table.htable[idx].begin(); itr != m_ch_table.htable[idx].end(); ++itr) {
+      if((*itr).rhv == rhv)
         return true;
     }
+
     return false;
   }
 
-  void chainInsert(uint64_t hv){
-    if (hash_table->usage < CACHE_SIZE){
-      ++hash_table->usage;
+  bool chainUpdate(uint64_t hv, std::vector<uint8_t> &rhv, const DATA_T&data){
+    uint32_t idx = hv % HASH_TABLE_SIZE;
+
+    m_ch_table.htable[idx];
+
+    if (m_ch_table.htable[idx].empty())
+      return false;
+
+    for (auto itr = m_ch_table.htable[idx].begin(); itr != m_ch_table.htable[idx].end(); ++itr) {
+      if((*itr).rhv == rhv) {
+        (*itr).data = data;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  std::optional<DATA_T> chainGet(uint64_t hv, std::vector<uint8_t> &rhv){
+
+    uint32_t idx = hv % HASH_TABLE_SIZE;
+
+    m_ch_table.htable[idx];
+
+    if (m_ch_table.htable[idx].empty()) {
+      return std::nullopt;
+    }
+
+    DATA_T ret_data;
+
+    bool found = false;
+
+    for (auto itr = m_ch_table.htable[idx].begin(); itr != m_ch_table.htable[idx].end(); ++itr) {
+      if ((*itr).rhv == rhv) {
+        ret_data = (*itr).data;
+        found = true;
+        break;
+      }
+    }
+
+    if(found)
+      return ret_data;
+
+    return std::nullopt;
+
+  }
+
+  void chainInsert(uint64_t hv, std::vector<uint8_t> &rhv, const DATA_T& data){
+    if (m_ch_table.usage < CACHE_SIZE){
+      ++m_ch_table.usage;
     }
     else{
-      uint64_t evict_hv = 0;
-      evict_hv = lruEvict();
+      uint64_t evict_hv = lruEvict();
       chainDelete(evict_hv);
     }
 
     uint32_t idx = hv % HASH_TABLE_SIZE;
-    std::shared_ptr<chain_entry> temp(new chain_entry);
-    temp->hv = hv;
-    temp->next = hash_table->htable[idx];
-    hash_table->htable[idx] = temp;
-
-    ++hash_table->insert;
+    DataEntry<DATA_T> tmp_data_entry;
+    tmp_data_entry.hv = hv;
+    tmp_data_entry.rhv = rhv;
+    tmp_data_entry.data = data;
+    m_ch_table.htable[idx].emplace_back(tmp_data_entry);
+    ++m_ch_table.insert;
 
     lruInsert(hv);
   }
 
   void chainDelete(uint64_t hv){
     uint32_t idx = hv % HASH_TABLE_SIZE;
-    std::shared_ptr<chain_entry> temp, ptr;
 
-    ptr = hash_table->htable[idx];
-    if (ptr == nullptr)
+    if (m_ch_table.htable[idx].empty())
       return;
 
-    if (ptr->hv == hv){
-      if (ptr->next != nullptr)
-        hash_table->htable[idx] = ptr->next;
-      else
-        hash_table->htable[idx] = nullptr;
-
-      ++(hash_table->evict);
-      return;
-    }
-
-    while (ptr->next != nullptr){
-      if (ptr->next->hv == hv){
-        temp = ptr->next;
-        ptr->next = temp->next;
-        ++(hash_table->evict);
-        return;
+    for (auto itr = m_ch_table.htable[idx].begin(); itr != m_ch_table.htable[idx].end(); ++itr) {
+      if((*itr).hv == hv) {
+        m_ch_table.htable[idx].erase(itr);
       }
-
-      ptr = ptr->next;
     }
   }
 
 
   void lruInit() {
-    lru_head = nullptr;
-    lru_tail = nullptr;
+    m_lru_list.clear();
   }
 
   void lruInsert(uint64_t hv) {
-    std::shared_ptr<lru_entry> new_entry(new lru_entry);
-    new_entry->hash_value = hv;
-
-    if (lru_head == nullptr)
-      lru_tail = new_entry;
-    else
-      lru_head->prev = new_entry;
-
-    new_entry->next = lru_head;
-    lru_head = new_entry;
+    m_lru_list.push_front(hv);
   }
 
   uint64_t lruEvict() {
-    std::shared_ptr<lru_entry> tmp = lru_tail;
-
-    if (lru_head == nullptr)
-      return 0;
-
-    if (lru_head->next == nullptr)
-      lru_head = nullptr;
-    else
-      lru_tail->prev->next = nullptr;
-
-    lru_tail = lru_tail->prev;
-
-    return tmp->hash_value;
+    uint64_t ret_val = 0;
+    if(!m_lru_list.empty()) {
+      ret_val = m_lru_list.back();
+      m_lru_list.pop_back();
+    }
+    return ret_val;
   }
 
   void lruUpdate(uint64_t hv) {
 
-    if (lru_head == nullptr)
-      return;
-
-    std::shared_ptr<lru_entry> current = lru_head;
-    while (current->hash_value != hv) {
-      if (current->next == nullptr)
-        return;
-      else
-        current = current->next;
+    for (auto itr = m_lru_list.begin(); itr != m_lru_list.end(); ++itr) {
+      if((*itr) == hv) {
+        m_lru_list.erase(itr);
+        break;
+      }
     }
-
-    if (current == lru_head)
-      lru_head = lru_head->next;
-    else
-      current->prev->next = current->next;
-
-    if (current == lru_tail)
-      lru_tail = current->prev;
-    else
-      current->next->prev = current->prev;
 
     lruInsert(hv);
   }
 
 
   void rccCreate(int layer) {
-    rcc.reset(new rcc32_t);
 
     if (layer == 1)
-      rcc->rcounter.resize(LC_COUNTER_SINGLEFR_IDXSIZE);
+      m_rcc.rcounter.resize(LC_COUNTER_SINGLEFR_IDXSIZE);
     else if (layer == 2)
-      rcc->rcounter.resize(LC_COUNTER_DOUBLEFRE_IDXSIZE);
+      m_rcc.rcounter.resize(LC_COUNTER_DOUBLEFRE_IDXSIZE);
 
-    std::fill(rcc->rcounter.begin(),rcc->rcounter.end(), 0);
+    std::fill(m_rcc.rcounter.begin(),m_rcc.rcounter.end(), 0);
 
-    rcc->htable.table.reserve(HASH_TABLE_SIZE);
+    m_rcc.htable.table.reserve(HASH_TABLE_SIZE);
     for (int i = 0; i < HASH_TABLE_SIZE; ++i) {
-      rcc->htable.table[i].hash_value = 0;
-      rcc->htable.table[i].total_counter = 0;
+      m_rcc.htable.table[i].hv = 0;
+      m_rcc.htable.table[i].total_counter = 0;
     }
-    rcc->htable.size = HASH_TABLE_SIZE;
-    rcc->htable.usage = 0;
-    rcc->htable.insert = 0;
-    rcc->htable.eviction = 0;
-    rcc->htable.total_jump = 0;
+    m_rcc.htable.size = HASH_TABLE_SIZE;
+    m_rcc.htable.usage = 0;
+    m_rcc.htable.insert = 0;
+    m_rcc.htable.eviction = 0;
+    m_rcc.htable.total_jump = 0;
 
     if (layer == 1)
-      rcc->memory_fr_limit = LC_COUNTER_SINGLEFR_IDXSIZE;
+      m_rcc.memory_fr_limit = LC_COUNTER_SINGLEFR_IDXSIZE;
     else if (layer == 2)
-      rcc->memory_fr_limit = LC_COUNTER_DOUBLEFRE_IDXSIZE / 6;
-
-    //rcc->memory_usage = 0;
-    //rcc->vector_size = VIRTUAL_VECTOER_SIZE;
+      m_rcc.memory_fr_limit = LC_COUNTER_DOUBLEFRE_IDXSIZE / 6;
   }
 
   inline uint32_t getMz(uint32_t word, uint32_t vector) {
-    float i = (32 - VIRTUAL_VECTOER_SIZE) - (getNumbSetBits(word) - getNumbSetBits(vector & word));
-    return (uint32_t)(i / ((32 / VIRTUAL_VECTOER_SIZE) - 1));
+    float i = (32 - VIRTUAL_VECTOR_SIZE) - (getNumbSetBits(word) - getNumbSetBits(vector & word));
+    return (uint32_t)(i / ((32 / VIRTUAL_VECTOR_SIZE) - 1));
   }
 
   float getKhat(float zeros, float mzeros) {
-    float Vs = (zeros / (VIRTUAL_VECTOER_SIZE - 1));
-    float Vm = ((mzeros) / (VIRTUAL_VECTOER_SIZE));
-    float cs = log(1.0 - 1.0 / (VIRTUAL_VECTOER_SIZE));			  // constant for tt
-    float k2 = -(VIRTUAL_VECTOER_SIZE - 1)*log(Vs);
+    float Vs = (zeros / (VIRTUAL_VECTOR_SIZE - 1));
+    float Vm = ((mzeros) / (VIRTUAL_VECTOR_SIZE));
+    float cs = log(1.0 - 1.0 / (VIRTUAL_VECTOR_SIZE)); // constant for tt
+    float k2 = -(VIRTUAL_VECTOR_SIZE - 1)*log(Vs);
     float k1 = log(Vm) / cs;
     float khat = k2 - k1;
     khat = (khat < 0) ? 0 : (khat);
@@ -412,31 +340,31 @@ private:
     return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
   }
 
-/* Insert a hash_value-value pair into a hash table. */
+/* Insert a hv-value pair into a hash table. */
 
   void htSet4(uint64_t hash_value, float est){
-    ++(rcc->htable.insert);
+    ++(m_rcc.htable.insert);
     uint32_t loc = 0;
     uint32_t min = -1;
     int expired_loc = -1;
-    int hsize = rcc->htable.size;
+    int hsize = m_rcc.htable.size;
 
     for (int64_t qp = 0; qp < JUMP_THRESHOLD; ++qp) {
       // prepare set to another place
-      loc = (hash_value + (qp + qp*qp) / 2) % hsize; // hash_value + 0.5i+ 0.5i^2
-      entry_t &me = rcc->htable.table[loc];
-      if (me.hash_value == 0){
-        me.hash_value = hash_value;
+      loc = (hash_value + (qp + qp*qp) / 2) % hsize; // hv + 0.5i+ 0.5i^2
+      Entry_t &me = m_rcc.htable.table[loc];
+      if (me.hv == 0){
+        me.hv = hash_value;
         me.total_counter = est;
 
-        rcc->htable.total_jump += (qp + 1);
-        ++(rcc->htable.usage);
+        m_rcc.htable.total_jump += (qp + 1);
+        ++(m_rcc.htable.usage);
         return;
       }
-      else if (me.hash_value == hash_value){
+      else if (me.hv == hash_value){
         me.total_counter += est;
 
-        rcc->htable.total_jump += (qp + 1);
+        m_rcc.htable.total_jump += (qp + 1);
         return;
       }
         // eviction target search
@@ -446,10 +374,10 @@ private:
       }
     }
 
-    rcc->htable.total_jump += JUMP_THRESHOLD;
-    rcc->htable.eviction++;
-    rcc->htable.table[expired_loc].hash_value = hash_value;  // expired
-    rcc->htable.table[expired_loc].total_counter = est;  // expired
+    m_rcc.htable.total_jump += JUMP_THRESHOLD;
+    m_rcc.htable.eviction++;
+    m_rcc.htable.table[expired_loc].hv = hash_value;  // expired
+    m_rcc.htable.table[expired_loc].total_counter = est;  // expired
   }
 
 /* single layer Flow Regulator에 입력 */
@@ -460,38 +388,39 @@ private:
     uint32_t vector = 0;
     uint64_t rehash = hv;
     int i = 0;
+    std::vector<uint8_t> dummy_rhv;
 
     uint64_t temp;
-    while (i < VIRTUAL_VECTOER_SIZE){
+    while (i < VIRTUAL_VECTOR_SIZE){
       ++left;
       temp = rehash;
       temp = (temp << left);
       temp = (temp >> right);
       vector |= (0x1 << temp);
       if (last_vector != vector){
-        i++;
+        ++i;
         last_vector = vector;
       }
       if (left == 59){
-        rehash = hash(rehash);
+        rehash = hash(rehash, dummy_rhv);
         left = -1;
       }
     }
 
-    uint32_t A_index = (hv % (rcc->memory_fr_limit));
+    uint32_t a_idx = (hv % (m_rcc.memory_fr_limit));
 
-    std::uniform_int_distribution<> rand_dist(0,VIRTUAL_VECTOER_SIZE-1);
+    std::uniform_int_distribution<> rand_dist(0,VIRTUAL_VECTOR_SIZE-1);
 
     //set random bit
     i = rand_dist(prng);
-    uint32_t composed_word = rcc->rcounter[A_index] | getBitmaskDIndex(vector, i);
-    uint32_t zeros = VIRTUAL_VECTOER_SIZE - getNumbSetBits(vector & composed_word);
+    uint32_t composed_word = m_rcc.rcounter[a_idx] | getBitmaskDIndex(vector, i);
+    uint32_t zeros = VIRTUAL_VECTOR_SIZE - getNumbSetBits(vector & composed_word);
 
-    if (zeros < ((double)VIRTUAL_VECTOER_SIZE * 0.3)) {
+    if (zeros < ((double)VIRTUAL_VECTOR_SIZE * 0.3)) {
       uint32_t mzeros = getMz(composed_word, vector);
       zeros = 2;
       if (mzeros <= 3)
-        mzeros = VIRTUAL_VECTOER_SIZE;
+        mzeros = VIRTUAL_VECTOR_SIZE;
 
       uint32_t bit_mask, test;
 
@@ -505,16 +434,35 @@ private:
         }
       }
 
-      rcc->rcounter[A_index] = composed_word;
+      m_rcc.rcounter[a_idx] = composed_word;
       float est = getKhat(2, mzeros) + 1;
 
-      rcc_qp_flag = true;
+      m_rcc_qp_flag = true;
       htSet4(hv, est);
     }
-    rcc->rcounter[A_index] = composed_word;
+    m_rcc.rcounter[a_idx] = composed_word;
   }
 
-  uint64_t hash(uint64_t msg_int) {
+  uint64_t hash(const std::string &key, std::vector<uint8_t> &rhv) {
+    std::vector<uint8_t> byte_data(key.begin(), key.end());
+
+    uint64_t ret_val;
+
+#ifdef USE_BOTAN_HASH
+    std::unique_ptr<Botan::HashFunction> hash_function(Botan::HashFunction::create("SHA-256"));
+    hash_function->update(byte_data);
+
+    rhv = hash_function->final_stdvec();
+    std::memcpy(&ret_val, rhv.data(), sizeof(uint64_t));
+#else
+
+#endif
+
+    return ret_val;
+
+  }
+
+  uint64_t hash(uint64_t msg_int, std::vector<uint8_t> &rhv) {
 
     std::vector<uint8_t> msg_bytes;
     auto input_size = sizeof(msg_int);
@@ -529,11 +477,11 @@ private:
     uint64_t ret_val;
 
 #ifdef USE_BOTAN_HASH
-    unique_ptr<Botan::HashFunction> hash_function(Botan::HashFunction::create("SHA-256"));
+    std::unique_ptr<Botan::HashFunction> hash_function(Botan::HashFunction::create("SHA-256"));
     hash_function->update(msg_bytes);
 
-    std::vector<uint8_t> hash_result = hash_function->final_stdvec();
-    std::memcpy(&ret_val, hash_result.data(), sizeof(uint64_t));
+    rhv = hash_function->final_stdvec();
+    std::memcpy(&ret_val, rhv.data(), sizeof(uint64_t));
 #else
 
 #endif

--- a/test/rccqp_test.cpp
+++ b/test/rccqp_test.cpp
@@ -1,0 +1,42 @@
+#define BOOST_TEST_MODULE rccqp_test
+
+#include <iostream>
+#include <boost/test/included/unit_test.hpp>
+#include "../include/rcc_qp.hpp"
+
+
+BOOST_AUTO_TEST_SUITE(rccqp_test)
+
+BOOST_AUTO_TEST_CASE(simple_push_get) {
+
+  tethys::RCCQP<std::string> rcc_cache;
+  std::string key = "abcdefg";
+  std::string data = "hello, world";
+
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+  rcc_cache.get(key);
+  rcc_cache.push(key,data);
+
+
+  std::cout << rcc_cache.get(key).value_or("") << std::endl;
+
+  BOOST_TEST(rcc_cache.get(key).value_or("") == data);
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### RCC_QP
- replaced linked lists based on pointer by STL container
- added some useful functions for real world uses

### DataManager
- used RCC_QP for user attributes and certificates caches

### Test
- added rcc_qp test code

### Warning
- RCC_QP(Recyclable Counter with Confinement - Quadratic Proving) 캐시는 일반 캐시와 다르게, 사용성이 낮은 것으로 판단되는 데이터는 캐시 자체에 넣질 않습니다. 그렇기 때문에, 지속적으로 캐시에 요청되는 데이터만 받게 됩니다. 확률적으로 판단하기 때문에, 적당한 횟수를 테스트하도록 되어 있는 테스트 코드가 성공할 수도 실패할 수도 있습니다. 횟수가 많아지면 점점 캐시에 담겨질 넣어질 확률이 높아집니다. 대신 한번 캐시에 들어가면 진짜 엄청 복잡한 상황이 아니면 캐시에서 빠지질 않기 때문에, 결과적으로 캐시 히트 확률이 대폭 높아진다고 합니다.
- 횟수가 보통 6회 이상이어야 하는데, 이게 수학적으로 최적이라고 합니다.